### PR TITLE
Fix broken build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ install:
 - conda install python=$TRAVIS_PYTHON_VERSION
 - conda install -q conda-build anaconda-client coverage sphinx
 script:
-- conda build ./recipe -c csdms-stack -c conda-forge
+- conda build ./recipe -c csdms-stack --old-build-string
 after_success:
-- curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py
-  > $HOME/anaconda_upload.py
-- echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack
-  --token=-
+- curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
+- echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-


### PR DESCRIPTION
This recipe was reported broken by Travis CI (the `permamodel` package couldn't be imported). The problem appears to be fixed, although I doubt it was anything I did. There are two changes in this PR:

1. Don't use the conda-forge channel when building the package. Use current, not future, versions of dependent packages.
1. Don't include the hash of dependencies in the filename of the built distribution. With builds based on cron jobs, this can lead to many versions of the same file. Let dependencies cause builds to break. 