### PR TITLE
Sync with permamodel v0.1.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,7 @@ source:
 requirements:
   build:
     - python
-    - setuptools
   run:
-    - python
     - numpy
     - scipy
     - netcdf4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "permamodel" %}
-{% set version = "0.1" %}
+{% set version = "0.1.1" %}
 
 package:
   name: {{ name }}
@@ -7,6 +7,7 @@ package:
 
 source:
   git_url: https://github.com/permamodel/permamodel
+  git_rev: v{{ version }}
 
 requirements:
   build:


### PR DESCRIPTION
Per discussion with @mcflugen, we want recipes in the Bakery to be tied to specific releases of the underlying software. This PR ties the permamodel recipe to v0.1.1.